### PR TITLE
Fix potential Null Pointer Exceptions if token is missing claims

### DIFF
--- a/WebJobs.Extensions.O365/Bindings/O365Extension.cs
+++ b/WebJobs.Extensions.O365/Bindings/O365Extension.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.WebJobs.Extensions
         public static string GetTokenOID(string rawToken)
         {
             var jwt = new JwtSecurityToken(rawToken);
-            return jwt.Claims.FirstOrDefault(claim => claim.Type == "oid").Value;
+            return jwt.Claims.FirstOrDefault(claim => claim.Type == "oid")?.Value;
         }
 
         /// <summary>
@@ -153,7 +153,11 @@ namespace Microsoft.Azure.WebJobs.Extensions
         public static string GetTokenOrderedScopes(string rawToken)
         {
             var jwt = new JwtSecurityToken(rawToken);
-            var stringScopes = jwt.Claims.FirstOrDefault(claim => claim.Type == "scp").Value;
+            var stringScopes = jwt.Claims.FirstOrDefault(claim => claim.Type == "scp")?.Value;
+            if(stringScopes != null)
+            {
+                return "";
+            }
             var scopes = stringScopes.Split(' ');
             Array.Sort(scopes);
             return string.Join(" ", scopes);

--- a/WebJobs.Extensions.O365/Bindings/O365Extension.cs
+++ b/WebJobs.Extensions.O365/Bindings/O365Extension.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Extensions
             var oidClaim = jwt.Claims.FirstOrDefault(claim => claim.Type == "oid");
             if (oidClaim == null)
             {
-                throw new InvalidOperationException("The graph token is missing an oid. Check your graph binding configuration.");
+                throw new InvalidOperationException("The graph token is missing an oid. Check your Microsoft Graph binding configuration.");
             }
             return oidClaim.Value;
         }
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.WebJobs.Extensions
             var stringScopes = jwt.Claims.FirstOrDefault(claim => claim.Type == "scp")?.Value;
             if(stringScopes != null)
             {
-                throw new InvalidOperationException("The graph token has no scopes. Ensure you have proper permissions to modify graph.");
+                throw new InvalidOperationException("The graph token has no scopes. Ensure your application is properly configured to access the Microsoft Graph.");
             }
             var scopes = stringScopes.Split(' ');
             Array.Sort(scopes);

--- a/WebJobs.Extensions.O365/Bindings/O365Extension.cs
+++ b/WebJobs.Extensions.O365/Bindings/O365Extension.cs
@@ -142,7 +142,12 @@ namespace Microsoft.Azure.WebJobs.Extensions
         public static string GetTokenOID(string rawToken)
         {
             var jwt = new JwtSecurityToken(rawToken);
-            return jwt.Claims.FirstOrDefault(claim => claim.Type == "oid")?.Value;
+            var oidClaim = jwt.Claims.FirstOrDefault(claim => claim.Type == "oid");
+            if (oidClaim == null)
+            {
+                throw new InvalidOperationException("The graph token is missing an oid. Check your graph binding configuration.");
+            }
+            return oidClaim.Value;
         }
 
         /// <summary>
@@ -156,7 +161,7 @@ namespace Microsoft.Azure.WebJobs.Extensions
             var stringScopes = jwt.Claims.FirstOrDefault(claim => claim.Type == "scp")?.Value;
             if(stringScopes != null)
             {
-                return "";
+                throw new InvalidOperationException("The graph token has no scopes. Ensure you have proper permissions to modify graph.");
             }
             var scopes = stringScopes.Split(' ');
             Array.Sort(scopes);


### PR DESCRIPTION
In it's current state, if the token is missing the claim "oid" or "scp", then the code will encounter a null pointer exception. While the chances that a token would be valid with either of these claims missing is minimal, if not possible, we should avoid null pointer exceptions and instead let the http requests encounter a 401 or 403 error, which is what we would expect when the token is missing these claims.