### PR TITLE
Reduce Binding inheritence

### DIFF
--- a/src/MicrosoftGraphBinding/Bindings/GraphTokenAttribute.cs
+++ b/src/MicrosoftGraphBinding/Bindings/GraphTokenAttribute.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.WebJobs
     /// Abstract attribute to be base class for all Graph-based binding attributes
     /// </summary>
     [Binding]
-    public abstract class GraphTokenAttribute : TokenAttribute
+    public abstract class GraphTokenAttribute : TokenBaseAttribute
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GraphTokenAttribute"/> class.

--- a/src/MicrosoftGraphBinding/Config/MicrosoftGraphExtensionConfig.cs
+++ b/src/MicrosoftGraphBinding/Config/MicrosoftGraphExtensionConfig.cs
@@ -351,7 +351,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph
                 {
                     var dummyTokenAttribute = new TokenAttribute()
                     {
-                        Resource = O365Constants.GraphBaseUrl,
                         Identity = TokenIdentityMode.UserFromToken,
                         UserToken = attribute.UserToken,
                         IdentityProvider = "AAD",

--- a/src/MicrosoftGraphBinding/Config/ServiceManager.cs
+++ b/src/MicrosoftGraphBinding/Config/ServiceManager.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services
         /// <returns>Authenticated GraphServiceClient</returns>
         internal async Task<IGraphServiceClient> GetMSGraphClientFromUserIdAsync(string userId)
         {
-            var attr = new TokenAttribute
+            var attr = new TokenAttribute()
             {
                 UserId = userId,
                 Resource = O365Constants.GraphBaseUrl,
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services
         /// </summary>
         /// <param name="attribute">Token attribute with either principal ID or ID token</param>
         /// <returns>Authenticated GSC</returns>
-        public virtual async Task<IGraphServiceClient> GetMSGraphClientAsync(TokenAttribute attribute)
+        public virtual async Task<IGraphServiceClient> GetMSGraphClientAsync(TokenBaseAttribute attribute)
         {
             string token = await this._tokenExtension.GetAccessTokenAsync(attribute);
             string principalId = GetTokenOID(token);

--- a/src/TokenBinding/AuthTokenExtensionConfig.cs
+++ b/src/TokenBinding/AuthTokenExtensionConfig.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
         /// </summary>
         /// <param name="attribute">TokenAttribute with desired resource & user's principal ID or ID token</param>
         /// <returns>JWT with audience, scopes, user id</returns>
-        public async Task<string> GetAccessTokenAsync(TokenAttribute attribute)
+        public async Task<string> GetAccessTokenAsync(TokenBaseAttribute attribute)
         {
             attribute.CheckValidity();
             switch (attribute.Identity)

--- a/src/TokenBinding/EasyAuthTokenClient.cs
+++ b/src/TokenBinding/EasyAuthTokenClient.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
             _log = log;
         }
 
-        private JwtSecurityToken GetTokenForEasyAuthAccess(TokenAttribute attribute)
+        private JwtSecurityToken GetTokenForEasyAuthAccess(TokenBaseAttribute attribute)
         {
             if (_tokenForEasyAuthAccess == null || _tokenForEasyAuthAccess.ValidTo <= DateTime.UtcNow.AddMinutes(_jwtExpirationBufferInMinutes))
             {
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
             return _tokenForEasyAuthAccess;
         }
 
-        public async Task<EasyAuthTokenStoreEntry> GetTokenStoreEntry(TokenAttribute attribute)
+        public async Task<EasyAuthTokenStoreEntry> GetTokenStoreEntry(TokenBaseAttribute attribute)
         {
             var jwt = GetTokenForEasyAuthAccess(attribute);
 
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
             }
         }
 
-        public async Task RefreshToken(TokenAttribute attribute)
+        public async Task RefreshToken(TokenBaseAttribute attribute)
         {
             if (string.IsNullOrEmpty(attribute.Resource))
             {
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
             }
         }
 
-        private JwtSecurityToken CreateTokenForEasyAuthAccess(TokenAttribute attribute)
+        private JwtSecurityToken CreateTokenForEasyAuthAccess(TokenBaseAttribute attribute)
         {
             if (string.IsNullOrEmpty(attribute.UserId))
             {

--- a/src/TokenBinding/EasyAuthTokenManager.cs
+++ b/src/TokenBinding/EasyAuthTokenManager.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
         /// </summary>
         /// <param name="attribute">The metadata for the token to grab</param>
         /// <returns>Task with Token Store entry of the token</returns>
-        public async Task<string> GetEasyAuthAccessTokenAsync(TokenAttribute attribute)
+        public async Task<string> GetEasyAuthAccessTokenAsync(TokenBaseAttribute attribute)
         {
             EasyAuthTokenStoreEntry tokenStoreEntry = await _client.GetTokenStoreEntry(attribute);
 

--- a/src/TokenBinding/IEasyAuthClient.cs
+++ b/src/TokenBinding/IEasyAuthClient.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
 
     internal interface IEasyAuthClient
     {
-        Task<EasyAuthTokenStoreEntry> GetTokenStoreEntry(TokenAttribute attribute);
+        Task<EasyAuthTokenStoreEntry> GetTokenStoreEntry(TokenBaseAttribute attribute);
 
-        Task RefreshToken(TokenAttribute attribute);
+        Task RefreshToken(TokenBaseAttribute attribute);
     }
 }

--- a/src/TokenBinding/TokenAttribute.cs
+++ b/src/TokenBinding/TokenAttribute.cs
@@ -1,83 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-namespace Microsoft.Azure.WebJobs
+namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
 {
     using Microsoft.Azure.WebJobs.Description;
-    using System;
 
+    //This class exists to allow rules to explicitly bind to the token attribute, while still having the logic
+    //contained in an abstract base class so that the Graph extension attributes can extend from that class. This prevents
+    //conflicts from an ExcelAttribute being both an ExcelAttribute and a TokenAttribute when determining what rules to follow.
     [Binding]
-    public class TokenAttribute : Attribute
+    public sealed class TokenAttribute : TokenBaseAttribute
     {
-        private TokenIdentityMode _identity;
-
-        /// <summary>
-        /// Gets or sets a resource for a token exchange. Optional
-        /// </summary>
-        public string Resource { get; set; }
-
-        /// <summary>
-        /// Gets or sets an identity provider for the token exchange. Optional
-        /// </summary>
-        public string IdentityProvider { get; set; }
-
-        /// <summary>
-        /// Gets or sets token to grab on-behalf-of. Required if Identity="userFromToken".
-        /// </summary>
-        [AutoResolve]
-        public string UserToken { get; set; }
-
-        /// <summary>
-        /// Gets or sets user id to grab token for. Required if Identity="userFromId".
-        /// </summary>
-        [AutoResolve]
-        public string UserId { get; set; }
-
-        /// <summary>
-        /// Gets or sets how to determine identity. Required.
-        /// </summary>
-        public TokenIdentityMode Identity
-        {
-            get
-            {
-                return _identity;
-            }
-
-            set
-            {
-                if (value == TokenIdentityMode.UserFromRequest)
-                {
-                    _identity = TokenIdentityMode.UserFromToken;
-                    this.UserToken = "{headers.X-MS-TOKEN-AAD-ID-TOKEN}";
-                }
-                else
-                {
-                    _identity = value;
-                }
-            }
-        }
-
-        public void CheckValidity()
-        {
-            switch (this.Identity)
-            {
-                case TokenIdentityMode.ClientCredentials:
-                    break;
-                case TokenIdentityMode.UserFromId:
-                    if (string.IsNullOrWhiteSpace(this.UserId))
-                    {
-                        throw new FormatException("A token attribute with identity=userFromId requires a userId");
-                    }
-
-                    break;
-                case TokenIdentityMode.UserFromToken:
-                    if (string.IsNullOrWhiteSpace(this.UserToken))
-                    {
-                        throw new FormatException("A token attribute with identity=userFromToken requires a userToken");
-                    }
-
-                    break;
-            }
-        }
     }
 }

--- a/src/TokenBinding/TokenBaseAttribute.cs
+++ b/src/TokenBinding/TokenBaseAttribute.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs
+{
+    using System;
+
+    public abstract class TokenBaseAttribute : Attribute
+    {
+        private TokenIdentityMode _identity;
+
+        /// <summary>
+        /// Gets or sets a resource for a token exchange. Optional
+        /// </summary>
+        public string Resource { get; set; }
+
+        /// <summary>
+        /// Gets or sets an identity provider for the token exchange. Optional
+        /// </summary>
+        public string IdentityProvider { get; set; }
+
+        /// <summary>
+        /// Gets or sets token to grab on-behalf-of. Required if Identity="userFromToken".
+        /// </summary>
+        [AutoResolve]
+        public string UserToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets user id to grab token for. Required if Identity="userFromId".
+        /// </summary>
+        [AutoResolve]
+        public string UserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets how to determine identity. Required.
+        /// </summary>
+        public TokenIdentityMode Identity
+        {
+            get
+            {
+                return _identity;
+            }
+
+            set
+            {
+                if (value == TokenIdentityMode.UserFromRequest)
+                {
+                    _identity = TokenIdentityMode.UserFromToken;
+                    this.UserToken = "{headers.X-MS-TOKEN-AAD-ID-TOKEN}";
+                }
+                else
+                {
+                    _identity = value;
+                }
+            }
+        }
+
+        public void CheckValidity()
+        {
+            switch (this.Identity)
+            {
+                case TokenIdentityMode.ClientCredentials:
+                    break;
+                case TokenIdentityMode.UserFromId:
+                    if (string.IsNullOrWhiteSpace(this.UserId))
+                    {
+                        throw new FormatException("A token attribute with identity=userFromId requires a userId");
+                    }
+
+                    break;
+                case TokenIdentityMode.UserFromToken:
+                    if (string.IsNullOrWhiteSpace(this.UserToken))
+                    {
+                        throw new FormatException("A token attribute with identity=userFromToken requires a userToken");
+                    }
+
+                    break;
+            }
+        }
+    }
+}

--- a/test/MicrosoftGraph.Tests/MockServiceManager.cs
+++ b/test/MicrosoftGraph.Tests/MockServiceManager.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Tests
             _client = client;
         }
 
-        public override Task<IGraphServiceClient> GetMSGraphClientAsync(TokenAttribute attribute)
+        public override Task<IGraphServiceClient> GetMSGraphClientAsync(TokenBaseAttribute attribute)
         {
             return Task.FromResult(_client);
         }

--- a/test/TokenExtension.Tests/TokenTests.cs
+++ b/test/TokenExtension.Tests/TokenTests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Token.Tests
         {
             var clientMock = new Mock<IEasyAuthClient>();
             var responseQueue = new Queue<EasyAuthTokenStoreEntry>(responsesInOrder);
-            clientMock.Setup(client => client.GetTokenStoreEntry(It.IsAny<TokenAttribute>()))
+            clientMock.Setup(client => client.GetTokenStoreEntry(It.IsAny<TokenBaseAttribute>()))
                 .Returns(Task.FromResult(responseQueue.Dequeue()));
             return clientMock;
         }


### PR DESCRIPTION
In order to prevent confusion with binding rules, have binding attributes only derive from abstract classes and don't put any binding rules on abstract classes.