### PR TITLE
Stop Excel Table input bindings from requiring worksheet name

### DIFF
--- a/WebJobs.Extensions.O365/Bindings/ExcelAsyncCollector.cs
+++ b/WebJobs.Extensions.O365/Bindings/ExcelAsyncCollector.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph
     using System.Threading.Tasks;
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services;
-    using Microsoft.Graph;
     using Newtonsoft.Json.Linq;
 
     /// <summary>

--- a/WebJobs.Extensions.O365/Services/ExcelClient.cs
+++ b/WebJobs.Extensions.O365/Services/ExcelClient.cs
@@ -12,30 +12,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services
     /// </summary>
     internal static class ExcelClient
     {
-        public static async Task<WorkbookTable> GetTableWorkbookAsync(this IGraphServiceClient client, string path, string worksheetName, string tableName)
+        public static async Task<WorkbookTable> GetTableWorkbookAsync(this IGraphServiceClient client, string path, string tableName)
         {
             return await client
-                .Me
-                .Drive
-                .Root
-                .ItemWithPath(path)
-                .Workbook
-                .Worksheets[worksheetName]
-                .Tables[tableName]
+                .GetWorkbookTableRequest(path, tableName)
                 .Request()
                 .GetAsync();
         }
 
-        public static async Task<WorkbookRange> GetTableWorkbookRangeAsync(this IGraphServiceClient client, string path, string worksheetName, string tableName)
+        public static async Task<WorkbookRange> GetTableWorkbookRangeAsync(this IGraphServiceClient client, string path, string tableName)
         {
             return await client
-                .Me
-                .Drive
-                .Root
-                .ItemWithPath(path)
-                .Workbook
-                .Worksheets[worksheetName]
-                .Tables[tableName]
+                .GetWorkbookTableRequest(path, tableName)
                 .Range()
                 .Request()
                 .GetAsync();
@@ -44,12 +32,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services
         public static async Task<WorkbookRange> GetWorksheetWorkbookAsync(this IGraphServiceClient client, string path, string worksheetName)
         {
             return await client
-                .Me
-                .Drive
-                .Root
-                .ItemWithPath(path)
-                .Workbook
-                .Worksheets[worksheetName]
+                .GetWorkbookWorksheetRequest(path, worksheetName)
                 .UsedRange()
                 .Request()
                 .GetAsync();
@@ -58,12 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services
         public static async Task<WorkbookRange> GetWorkSheetWorkbookInRangeAsync(this IGraphServiceClient client, string path, string worksheetName, string range)
         {
             return await client
-                .Me
-                .Drive
-                .Root
-                .ItemWithPath(path)
-                .Workbook
-                .Worksheets[worksheetName]
+                .GetWorkbookWorksheetRequest(path, worksheetName)
                 .Range(range)
                 .Request()
                 .GetAsync();
@@ -72,12 +50,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services
         public static async Task<string[]> GetTableHeaderRowAsync(this IGraphServiceClient client, string path, string tableName)
         {
             var headerRowRange = await client
-                .Me
-                .Drive
-                .Root
-                .ItemWithPath(path)
-                .Workbook
-                .Tables[tableName]
+                .GetWorkbookTableRequest(path, tableName)
                 .HeaderRowRange()
                 .Request()
                 .GetAsync();
@@ -87,12 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services
         public static async Task<WorkbookTableRow> PostTableRowAsync(this IGraphServiceClient client, string path, string tableName, JToken row)
         {
             return await client
-                .Me
-                .Drive
-                .Root
-                .ItemWithPath(path)
-                .Workbook
-                .Tables[tableName]
+                .GetWorkbookTableRequest(path, tableName)
                 .Rows
                 .Add(null, row)
                 .Request()
@@ -102,15 +70,33 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services
         public static async Task<WorkbookRange> PatchWorksheetAsync(this IGraphServiceClient client, string path, string worksheetName, string range, WorkbookRange newWorkbook)
         {
             return await client
+                .GetWorkbookWorksheetRequest(path, worksheetName)
+                .Range(range)
+                .Request()
+                .PatchAsync(newWorkbook);
+        }
+
+
+        internal static IWorkbookTableRequestBuilder GetWorkbookTableRequest(this IGraphServiceClient client, string path, string tableName)
+        {
+            return client
                 .Me
                 .Drive
                 .Root
                 .ItemWithPath(path)
                 .Workbook
-                .Worksheets[worksheetName]
-                .Range(range)
-                .Request()
-                .PatchAsync(newWorkbook);
+                .Tables[tableName];
+        }
+
+        internal static IWorkbookWorksheetRequestBuilder GetWorkbookWorksheetRequest(this IGraphServiceClient client, string path, string worksheetName)
+        {
+            return client
+                .Me
+                .Drive
+                .Root
+                .ItemWithPath(path)
+                .Workbook
+                .Worksheets[worksheetName];
         }
     }
 }

--- a/WebJobs.Extensions.O365/Services/ExcelService.cs
+++ b/WebJobs.Extensions.O365/Services/ExcelService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services
 
         internal Task<WorkbookTable> GetExcelTable(ExcelAttribute attr)
         {
-            return _client.GetTableWorkbookAsync(attr.Path, attr.WorksheetName, attr.TableName);
+            return _client.GetTableWorkbookAsync(attr.Path, attr.TableName);
         }
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services
             // If TableName is set, then retrieve the contents of a table
             if (attr.TableName != null)
             {
-                range = await _client.GetTableWorkbookRangeAsync(attr.Path, attr.WorksheetName, attr.TableName);
+                range = await _client.GetTableWorkbookRangeAsync(attr.Path, attr.TableName);
             }
             else
             {
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services
             // The table API only allows updating or adding one row at a time.
             // Instead we update the worksheet range corresponding to the table
 
-            string currentTableRange = (await _client.GetTableWorkbookRangeAsync(attr.Path, attr.WorksheetName, attr.TableName)).Address;
+            string currentTableRange = (await _client.GetTableWorkbookRangeAsync(attr.Path, attr.TableName)).Address;
 
             // Retrieve current worksheet rows
             WorkbookRange currentTableWorkbook = await _client.GetWorkSheetWorkbookInRangeAsync(attr.Path, attr.WorksheetName, currentTableRange);

--- a/test/MicrosoftGraph.Tests/ExcelMockUtilities.cs
+++ b/test/MicrosoftGraph.Tests/ExcelMockUtilities.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Tests
                 .Root
                 .ItemWithPath(It.IsAny<string>())
                 .Workbook
-                .Worksheets[It.IsAny<string>()]
                 .Tables[It.IsAny<string>()]
                 .Request()
                 .GetAsync()).Returns(Task.FromResult(returnValue));
@@ -34,7 +33,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Tests
                 .Root
                 .ItemWithPath(It.IsAny<string>())
                 .Workbook
-                .Worksheets[It.IsAny<string>()]
                 .Tables[It.IsAny<string>()]
                 .Range()
                 .Request(null)
@@ -141,7 +139,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Tests
                 .Request(null)
                 .PatchAsync(It.Is<WorkbookRange>(newWorkbookCondition)));
         }
-
-
     }
 }

--- a/test/MicrosoftGraph.Tests/ExcelTests.cs
+++ b/test/MicrosoftGraph.Tests/ExcelTests.cs
@@ -278,10 +278,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Tests
 
         private class ExcelInputFunctions
         {
-            public void GetWorkbookTable(
-                [Excel(
+            public void GetWorkbookTable([Excel(
                 Path = path,
-                WorksheetName = worksheetName,
                 TableName = tableName)] WorkbookTable table)
             {
                 finalTable = table;
@@ -290,7 +288,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Tests
             public void GetExcelTableRange(
                 [Excel(
                 Path = path,
-                WorksheetName = worksheetName,
                 TableName = tableName)] string[][] range)
             {
                 finalRange = range;


### PR DESCRIPTION
Fix for #22.

Before we were using the latter of the two calls found here https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/api/table_get, but using the first we can circumvent the need for the worksheet name.