### PR TITLE
Support on-behalf-of graph subscription refreshes

### DIFF
--- a/samples/GraphExtensionSamples/WebhookSubscriptionExamples.cs
+++ b/samples/GraphExtensionSamples/WebhookSubscriptionExamples.cs
@@ -7,8 +7,9 @@ namespace GraphExtensionSamples
 
     public static class WebhookSubscriptionExamples
     {
+        //Note that this function will only pass if the ClientCredentials identity has permission to refresh all of the available webhooks
         public static void RefreshAllSubscriptions(
-            [GraphWebhookSubscription(Identity = TokenIdentityMode.ClientCredentials)] string[] subIds,
+            [GraphWebhookSubscription] string[] subIds, 
             [GraphWebhookSubscription(
             Action = GraphWebhookSubscriptionAction.Refresh,
             Identity = TokenIdentityMode.ClientCredentials)] ICollector<string> refreshedSubscriptions)
@@ -16,6 +17,43 @@ namespace GraphExtensionSamples
             foreach (var subId in subIds)
             {
                 refreshedSubscriptions.Add(subId);
+            }
+        }
+
+        //This more complicated function without setting up an application identity with lots of permissions
+        public static async void RefreshAllSubscriptionsWithoutClientCredentials(
+            [GraphWebhookSubscription] SubscriptionPoco[] existingSubscriptions,
+            IBinder binder)
+        {
+            foreach (var subscription in existingSubscriptions)
+            {
+                // binding in code to allow dynamic identity
+                var subscriptionsToRefresh = await binder.BindAsync<IAsyncCollector<string>>(
+                    new GraphWebhookSubscriptionAttribute()
+                    {
+                        Action = GraphWebhookSubscriptionAction.Refresh,
+                        Identity = TokenIdentityMode.UserFromId,
+                        UserId = subscription.UserId
+                    }
+                );
+                {
+                    await subscriptionsToRefresh.AddAsync(subscription.Id);
+                }
+            }
+        }
+
+        public static void RefreshSubscriptionsSelectively(
+            [GraphWebhookSubscription] SubscriptionPoco[] existingSubscriptions,
+            [GraphWebhookSubscription(
+            Action = GraphWebhookSubscriptionAction.Refresh,
+            Identity = TokenIdentityMode.ClientCredentials)] ICollector<string> refreshedSubscriptions)
+        {
+            foreach (var subscription in existingSubscriptions)
+            {
+                if(subscription.ChangeType.Equals("updated") && subscription.ODataType.Equals("#Microsoft.Graph.Message"))
+                {
+                    refreshedSubscriptions.Add(subscription.Id);
+                }   
             }
         }
 
@@ -40,5 +78,21 @@ namespace GraphExtensionSamples
         {
             clientState = Guid.NewGuid().ToString();
         }
+
+        public class SubscriptionPoco
+        {
+            public string UserId { get; set; }
+            //All of the below are properties of the Subscription object that can be used in your custom POCO
+            //See https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/81c50e72166152f9f84dc38b2516379b7a536300/src/Microsoft.Graph/Models/Generated/Subscription.cs
+            //for usage
+            public string Id { get; set; }
+            public string ODataType { get; set; }
+            public string Resource { get; set; }
+            public string ChangeType { get; set; }
+            public string ClientState { get; set; }
+            public string NotificationUrl { get; set; }
+            public DateTimeOffset? ExpirationDateTime { get; set; }
+        }
+        
     }
 }

--- a/src/MicrosoftGraphBinding/Bindings/GraphWebhookSubscriptionAsyncCollector.cs
+++ b/src/MicrosoftGraphBinding/Bindings/GraphWebhookSubscriptionAsyncCollector.cs
@@ -145,8 +145,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph
             }
             catch (Exception ex)
             {
-                _log.Info($"Failed to renew MS Graph subscription {id}.\n Either it never existed or it has already expired.");
-
                 // If the subscription is expired, it can no longer be renewed, so delete the file
                 var subscriptionEntry = await _webhookConfig.SubscriptionStore.GetSubscriptionEntryAsync(id);
                 if (subscriptionEntry != null)
@@ -156,8 +154,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph
                         _webhookConfig.SubscriptionStore.DeleteAsync(id);
                     } else
                     {
-                        _log.Error("Present non-expired subscription failed to renew", ex);
+                        _log.Error("A non-expired subscription failed to renew", ex);
                     }
+                } else
+                {
+                    _log.Warning("The subscription with id " + id + " was not present in the local subscription store.");
                 }
             }
         }

--- a/src/MicrosoftGraphBinding/Config/Converters/ExcelConverters.cs
+++ b/src/MicrosoftGraphBinding/Config/Converters/ExcelConverters.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Config.Converters
+{
+    using System.Linq;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services;
+    using Newtonsoft.Json.Linq;
+    using Microsoft.Graph;
+
+    internal class ExcelConverters
+    {
+        internal class ExcelConverter : 
+            IAsyncConverter<ExcelAttribute, string[][]>,
+            IAsyncConverter<ExcelAttribute, WorkbookTable>
+        {
+            private readonly ServiceManager _serviceManager;
+
+            public ExcelConverter(ServiceManager serviceManager)
+            {
+                _serviceManager = serviceManager;
+            }
+
+            public IAsyncCollector<JObject> CreateCollector(ExcelAttribute attr)
+            {
+                var service = Task.Run(() => _serviceManager.GetExcelService(attr)).GetAwaiter().GetResult();
+                return new ExcelAsyncCollector(service, attr);
+            }
+            async Task<string[][]> IAsyncConverter<ExcelAttribute, string[][]>.ConvertAsync(ExcelAttribute attr, CancellationToken cancellationToken)
+            {
+                var service = await _serviceManager.GetExcelService(attr);
+                return await service.GetExcelRangeAsync(attr);
+            }
+
+            async Task<WorkbookTable> IAsyncConverter<ExcelAttribute, WorkbookTable>.ConvertAsync(ExcelAttribute input, CancellationToken cancellationToken)
+            {
+                var service = await _serviceManager.GetExcelService(input);
+                return await service.GetExcelTable(input);
+            }
+        }
+
+        /// <summary>
+        /// Used to convert POCOs to JObjects (for Excel output bindings)
+        /// T -> used to append a row
+        /// T[] -> used to update a table
+        /// </summary>
+        /// <typeparam name="T">Generic POCO type</typeparam>
+        internal class GenericExcelRowConverter<T> : IConverter<List<T>, JObject>, IConverter<T, JObject>
+        {
+            /// <summary>
+            /// Convert from POCO -> JObject (either row or rows)
+            /// </summary>
+            /// <param name="input">POCO input from fx</param>
+            /// <returns>JObject with proper keys set</returns>
+            public JObject Convert(T input)
+            {
+                // handle T[]
+                if (typeof(T).IsArray)
+                {
+                    var array = input as object[];
+                    return ConvertEnumerable(array);
+                }
+                else
+                {
+                    // handle T
+                    JObject data = JObject.FromObject(input);
+                    data[O365Constants.POCOKey] = true; // Set Microsoft.O365Bindings.POCO flag to indicate that data is from POCO (vs. object[][])
+
+                    return data;
+                }
+            }
+
+            /// <summary>
+            /// Convert from List<POCO> -> JObject
+            /// </summary>
+            /// <param name="input">POCO input from fx</param>
+            /// <returns>JObject with proper keys set</returns>
+            public JObject Convert(List<T> input)
+            {
+                return ConvertEnumerable(input);
+            }
+
+            private JObject ConvertEnumerable<U>(IEnumerable<U> input)
+            {
+                JObject jsonContent = new JObject();
+
+                JArray rowData = JArray.FromObject(input);
+
+                // List<T> -> JArray
+                jsonContent[O365Constants.ValuesKey] = rowData;
+
+                // Set rows, columns needed if updating entire worksheet
+                jsonContent[O365Constants.RowsKey] = rowData.Count();
+
+                // No exception -- array is rectangular by default
+                jsonContent[O365Constants.ColsKey] = rowData.First.Count();
+
+                // Set POCO key to indicate that the values need to be ordered to match the header of the existing table
+                jsonContent[O365Constants.POCOKey] = true;
+
+                return jsonContent;
+            }
+        }
+
+        /// <summary>
+        /// Used for INPUT bindings: convert Excel Attribute -> POCO inputs
+        /// </summary>
+        /// <typeparam name="T">POCO type user wishes to bind Excel contents to</typeparam>
+        internal class POCOExcelRowConverter<T> : IAsyncConverter<ExcelAttribute, T[]>, IAsyncConverter<ExcelAttribute, List<T>>
+            where T : new()
+        {
+            private readonly ServiceManager _serviceManager;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="POCOExcelRowConverter{T}"/> class.
+            /// </summary>
+            /// <param name="parent">O365Extension to which the result of the request for data will be returned</param>
+            public POCOExcelRowConverter(ServiceManager serviceManager)
+            {
+                this._serviceManager = serviceManager;
+            }
+
+            async Task<List<T>> IAsyncConverter<ExcelAttribute, List<T>>.ConvertAsync(ExcelAttribute input, CancellationToken cancellationToken)
+            {
+                var manager = await _serviceManager.GetExcelService(input);
+                return await manager.GetExcelRangePOCOListAsync<T>(input);
+            }
+
+            async Task<T[]> IAsyncConverter<ExcelAttribute, T[]>.ConvertAsync(ExcelAttribute input, CancellationToken cancellationToken)
+            {
+                var manager = await _serviceManager.GetExcelService(input);
+                return await manager.GetExcelRangePOCOAsync<T>(input);
+            }
+
+            public IAsyncCollector<JObject> CreateCollector(ExcelAttribute attr)
+            {
+                var manager = Task.Run(() => _serviceManager.GetExcelService(attr)).GetAwaiter().GetResult();
+                return new ExcelAsyncCollector(manager, attr);
+            }
+        }
+    }
+}

--- a/src/MicrosoftGraphBinding/Config/Converters/GraphWebhookSubscriptionConverters.cs
+++ b/src/MicrosoftGraphBinding/Config/Converters/GraphWebhookSubscriptionConverters.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Config.Converters
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services;
+    using Microsoft.Graph;
+    using Newtonsoft.Json.Linq;
+
+    internal class GraphWebhookSubscriptionConverters
+    {
+        internal class GraphWebhookSubscriptionConverter :
+            IAsyncConverter<GraphWebhookSubscriptionAttribute, Subscription[]>,
+            IAsyncConverter<GraphWebhookSubscriptionAttribute, string[]>,
+            IAsyncConverter<GraphWebhookSubscriptionAttribute, JArray>
+        {
+            private readonly ServiceManager _serviceManager;
+            private readonly GraphWebhookConfig _webhookConfig;
+
+            public GraphWebhookSubscriptionConverter(ServiceManager serviceManager, GraphWebhookConfig webhookConfig)
+            {
+                _serviceManager = serviceManager;
+                _webhookConfig = webhookConfig;
+            }
+
+            async Task<Subscription[]> IAsyncConverter<GraphWebhookSubscriptionAttribute, Subscription[]>.ConvertAsync(GraphWebhookSubscriptionAttribute input, CancellationToken cancellationToken)
+            {
+                return (await GetSubscriptionsFromAttribute(input)).Select(entry => entry.Subscription).ToArray();
+            }
+
+            async Task<string[]> IAsyncConverter<GraphWebhookSubscriptionAttribute, string[]>.ConvertAsync(GraphWebhookSubscriptionAttribute input, CancellationToken cancellationToken)
+            {
+                Subscription[] subscriptions = (await GetSubscriptionsFromAttribute(input)).Select(entry => entry.Subscription).ToArray();
+                return subscriptions.Select(sub => sub.Id).ToArray();
+            }
+
+            async Task<JArray> IAsyncConverter<GraphWebhookSubscriptionAttribute, JArray>.ConvertAsync(GraphWebhookSubscriptionAttribute input, CancellationToken cancellationToken)
+            {
+                SubscriptionEntry[] subscriptions = await GetSubscriptionsFromAttribute(input);
+                var serializedSubscriptions = new JArray();
+                foreach (var subscription in subscriptions)
+                {
+                    serializedSubscriptions.Add(JObject.FromObject(subscription));
+                }
+                return serializedSubscriptions;
+            }
+
+            protected async Task<SubscriptionEntry[]> GetSubscriptionsFromAttribute(GraphWebhookSubscriptionAttribute attribute)
+            {
+                IEnumerable<SubscriptionEntry> subscriptionEntries = await _webhookConfig.SubscriptionStore.GetAllSubscriptionsAsync();
+                if (TokenIdentityMode.UserFromRequest.ToString().Equals(attribute.Filter, StringComparison.OrdinalIgnoreCase))
+                {
+                    var dummyTokenAttribute = new TokenAttribute()
+                    {
+                        Resource = O365Constants.GraphBaseUrl,
+                        Identity = TokenIdentityMode.UserFromToken,
+                        UserToken = attribute.UserToken,
+                        IdentityProvider = "AAD",
+                    };
+                    var graph = await _serviceManager.GetMSGraphClientAsync(dummyTokenAttribute);
+                    var user = await graph.Me.Request().GetAsync();
+                    subscriptionEntries = subscriptionEntries.Where(entry => entry.UserId.Equals(user.Id));
+                }
+                else if (attribute.Filter != null)
+                {
+                    throw new InvalidOperationException($"There is no filter for {attribute.Filter}");
+                }
+                return subscriptionEntries.ToArray();
+            }
+        }
+
+        internal class GenericGraphWebhookSubscriptionConverter<T> : GraphWebhookSubscriptionConverter,
+            IAsyncConverter<GraphWebhookSubscriptionAttribute, T[]>
+        {
+            public GenericGraphWebhookSubscriptionConverter(ServiceManager serviceManager, GraphWebhookConfig webhookConfig) : base(serviceManager, webhookConfig)
+            {
+            }
+
+            public async Task<T[]> ConvertAsync(GraphWebhookSubscriptionAttribute input, CancellationToken cancellationToken)
+            {
+                return ConvertSubscriptionEntries(await this.GetSubscriptionsFromAttribute(input));
+            }
+
+            //Converts a Subscription Entry into a "flattened" POCO representation where the properties 
+            //of the POCO can be UserId or any of the properties of Subscription
+            public T[] ConvertSubscriptionEntries(SubscriptionEntry[] entries)
+            {
+                var pocoType = typeof(T);
+                var subEntryType = typeof(Subscription);
+                var subscriptionProperties = subEntryType.GetProperties();
+                var pocoProperties = pocoType.GetProperties();
+
+                T[] pocos = new T[entries.Length];
+                for(int i = 0; i < pocos.Length; i++)
+                {
+                    pocos[i] = (T)Activator.CreateInstance(typeof(T), new object[] { });
+                }
+
+                foreach (PropertyInfo pocoProperty in pocoProperties)
+                {
+                    var subscriptionProperty = subEntryType.GetProperty(pocoProperty.Name, pocoProperty.PropertyType);
+                    if(subscriptionProperty != null)
+                    {
+                        for(int i = 0; i < pocos.Length; i++)
+                        {
+                            pocoProperty.SetValue(pocos[i], subscriptionProperty.GetValue(entries[i].Subscription));
+                        }
+                    }
+                }
+
+                var pocoUserIdProperty = pocoType.GetProperty("UserId");
+                if (pocoUserIdProperty != null)
+                {
+                    var subEntryUserIdProperty = typeof(SubscriptionEntry).GetProperty("UserId");
+                    for (int i = 0; i < pocos.Length; i++)
+                    {
+                        pocoUserIdProperty.SetValue(pocos[i], subEntryUserIdProperty.GetValue(entries[i]));
+                    }
+                }
+
+                return pocos;
+            }
+        }
+    }
+}

--- a/src/MicrosoftGraphBinding/Config/Converters/OneDriveConverter.cs
+++ b/src/MicrosoftGraphBinding/Config/Converters/OneDriveConverter.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Config.Converters
+{
+    using System.IO;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services;
+    using Microsoft.Graph;
+
+    class OneDriveConverter :
+        IAsyncConverter<OneDriveAttribute, byte[]>,
+        IAsyncConverter<OneDriveAttribute, string>,
+        IAsyncConverter<OneDriveAttribute, Stream>,
+        IAsyncConverter<OneDriveAttribute, DriveItem>
+    {
+        private readonly ServiceManager _serviceManager;
+
+        public OneDriveConverter(ServiceManager serviceManager)
+        {
+            _serviceManager = serviceManager;
+        }
+
+        async Task<byte[]> IAsyncConverter<OneDriveAttribute, byte[]>.ConvertAsync(OneDriveAttribute input, CancellationToken cancellationToken)
+        {
+            var service = await _serviceManager.GetOneDriveService(input);
+            return await service.GetOneDriveContentsAsByteArrayAsync(input);
+        }
+
+        async Task<string> IAsyncConverter<OneDriveAttribute, string>.ConvertAsync(OneDriveAttribute input, CancellationToken cancellationToken)
+        {
+            var service = await _serviceManager.GetOneDriveService(input);
+            var byteArray = await service.GetOneDriveContentsAsByteArrayAsync(input);
+            return Encoding.UTF8.GetString(byteArray);
+        }
+
+        async Task<Stream> IAsyncConverter<OneDriveAttribute, Stream>.ConvertAsync(OneDriveAttribute input, CancellationToken cancellationToken)
+        {
+            var service = await _serviceManager.GetOneDriveService(input);
+            return await service.GetOneDriveContentsAsStreamAsync(input);
+        }
+
+        async Task<DriveItem> IAsyncConverter<OneDriveAttribute, DriveItem>.ConvertAsync(OneDriveAttribute input, CancellationToken cancellationToken)
+        {
+            var service = await _serviceManager.GetOneDriveService(input);
+            return await service.GetOneDriveItemAsync(input);
+        }
+    }
+}

--- a/src/MicrosoftGraphBinding/Config/MicrosoftGraphExtensionConfig.cs
+++ b/src/MicrosoftGraphBinding/Config/MicrosoftGraphExtensionConfig.cs
@@ -17,12 +17,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.AuthTokens;
     using Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Config;
+    using Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Config.Converters;
     using Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services;
     using Microsoft.Azure.WebJobs.Host;
     using Microsoft.Azure.WebJobs.Host.Bindings;
     using Microsoft.Azure.WebJobs.Host.Config;
     using Microsoft.Graph;
     using Newtonsoft.Json.Linq;
+    using static Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Config.Converters.ExcelConverters;
+    using static Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Config.Converters.GraphWebhookSubscriptionConverters;
 
     /// <summary>
     /// WebJobs SDK Extension for O365 Token binding.
@@ -63,47 +66,47 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph
             var webhookTriggerProvider = new WebhookTriggerBindingProvider();
             _webhookConfig = new GraphWebhookConfig(context.GetWebhookHandler(), subscriptionStore, webhookTriggerProvider);
 
-            var converter = new Converters(_serviceManager, _webhookConfig);
-
-            // Extend token attribute to retrieve [authenticated] GraphServiceClient
-            //this.tokenExtension.TokenRule.BindToInput<GraphServiceClient>(converter);
+            var graphWebhookConverter = new GraphWebhookSubscriptionConverter(_serviceManager, _webhookConfig);
 
             // Webhooks
             var webhookSubscriptionRule = context.AddBindingRule<GraphWebhookSubscriptionAttribute>();
-
-            webhookSubscriptionRule.BindToInput<Subscription[]>(converter);
-            webhookSubscriptionRule.BindToInput<string[]>(converter);
-            webhookSubscriptionRule.BindToInput<JArray>(converter);
+            webhookSubscriptionRule.BindToInput<Subscription[]>(graphWebhookConverter);
+            webhookSubscriptionRule.BindToInput<OpenType[]>(typeof(GenericGraphWebhookSubscriptionConverter<>), _serviceManager, _webhookConfig);
+            webhookSubscriptionRule.BindToInput<string[]>(graphWebhookConverter);
+            webhookSubscriptionRule.BindToInput<JArray>(graphWebhookConverter);
             webhookSubscriptionRule.BindToCollector<string>(CreateCollector);
 
             context.AddBindingRule<GraphWebhookTriggerAttribute>().BindToTrigger(webhookTriggerProvider);
 
             // OneDrive
             var OneDriveRule = context.AddBindingRule<OneDriveAttribute>();
+            var oneDriveConverter = new OneDriveConverter(_serviceManager);
 
             // OneDrive inputs
-            OneDriveRule.BindToInput<byte[]>(converter);
-            OneDriveRule.BindToInput<string>(converter);
-            OneDriveRule.BindToInput<Stream>(converter);
-            OneDriveRule.BindToInput<DriveItem>(converter);
+            OneDriveRule.BindToInput<byte[]>(oneDriveConverter);
+            OneDriveRule.BindToInput<string>(oneDriveConverter);
+            OneDriveRule.BindToInput<Stream>(oneDriveConverter);
+            OneDriveRule.BindToInput<DriveItem>(oneDriveConverter);
 
-            OneDriveRule.BindToCollector<byte[]>(converter.CreateCollector);
+            OneDriveRule.BindToCollector<byte[]>(CreateCollector);
 
             // Excel
             var ExcelRule = context.AddBindingRule<ExcelAttribute>();
 
+            var excelConverter = new ExcelConverter(_serviceManager);
+
             // Excel Outputs
             ExcelRule.AddConverter<object[][], JObject>(ExcelService.CreateRows);
-            ExcelRule.AddConverter<List<OpenType>, JObject>(typeof(GenericConverter<>)); // used to append/update lists of POCOs
-            ExcelRule.AddConverter<OpenType, JObject>(typeof(GenericConverter<>)); // used to append/update arrays of POCOs
-            ExcelRule.BindToCollector<JObject>(converter.CreateCollector);
-            ExcelRule.BindToCollector<JObject>(typeof(POCOConverter<>));
+            ExcelRule.AddConverter<List<OpenType>, JObject>(typeof(GenericExcelRowConverter<>)); // used to append/update lists of POCOs
+            ExcelRule.AddConverter<OpenType, JObject>(typeof(GenericExcelRowConverter<>)); // used to append/update arrays of POCOs
+            ExcelRule.BindToCollector<JObject>(excelConverter.CreateCollector);
+            ExcelRule.BindToCollector<JObject>(typeof(POCOExcelRowConverter<>));
 
             // Excel Inputs
-            ExcelRule.BindToInput<string[][]>(converter);
-            ExcelRule.BindToInput<WorkbookTable>(converter);
-            ExcelRule.BindToInput<List<OpenType>>(typeof(POCOConverter<>), _serviceManager);
-            ExcelRule.BindToInput<OpenType>(typeof(POCOConverter<>), _serviceManager);
+            ExcelRule.BindToInput<string[][]>(excelConverter);
+            ExcelRule.BindToInput<WorkbookTable>(excelConverter);
+            ExcelRule.BindToInput<List<OpenType>>(typeof(POCOExcelRowConverter<>), _serviceManager);
+            ExcelRule.BindToInput<OpenType>(typeof(POCOExcelRowConverter<>), _serviceManager);
 
             // Outlook
             var OutlookRule = context.AddBindingRule<OutlookAttribute>();
@@ -111,7 +114,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph
             // Outlook Outputs
             OutlookRule.AddConverter<JObject, Message>(OutlookService.CreateMessage);
             OutlookRule.AddConverter<string, Message>(OutlookService.CreateMessage);
-            OutlookRule.BindToCollector<Message>(converter.CreateCollector);
+            OutlookRule.BindToCollector<Message>(CreateCollector);
         }
 
         private void ConfigureServiceManager(ExtensionConfigContext context)
@@ -125,10 +128,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph
             }
         }
 
-        public IAsyncCollector<string> CreateCollector(GraphWebhookSubscriptionAttribute attr)
+        private IAsyncCollector<string> CreateCollector(GraphWebhookSubscriptionAttribute attr)
         {
             return new GraphWebhookSubscriptionAsyncCollector(_serviceManager, _log, _webhookConfig, attr);
         }
+
+        private IAsyncCollector<Message> CreateCollector(OutlookAttribute attr)
+        {
+            var service = Task.Run(() => _serviceManager.GetOutlookService(attr)).GetAwaiter().GetResult();
+            return new OutlookAsyncCollector(service);
+        }
+
+        private IAsyncCollector<byte[]> CreateCollector(OneDriveAttribute attr)
+        {
+            var service = Task.Run(() => _serviceManager.GetOneDriveService(attr)).GetAwaiter().GetResult();
+            return new OneDriveAsyncCollector(service, attr);
+        }
+
 
         /// <summary>
         /// HttpRequest -> HttpResponse
@@ -142,231 +158,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph
             var handler = new GraphWebhookSubscriptionHandler(_serviceManager, _webhookConfig, _log);
             var response = await handler.ProcessAsync(input);
             return response;
-        }
-
-        /// <summary>
-        /// Used to convert POCOs to JObjects (for Excel output bindings)
-        /// T -> used to append a row
-        /// T[] -> used to update a table
-        /// </summary>
-        /// <typeparam name="T">Generic POCO type</typeparam>
-        public class GenericConverter<T> : IConverter<List<T>, JObject>, IConverter<T, JObject>
-        {
-            /// <summary>
-            /// Convert from POCO -> JObject (either row or rows)
-            /// </summary>
-            /// <param name="input">POCO input from fx</param>
-            /// <returns>JObject with proper keys set</returns>
-            public JObject Convert(T input)
-            {
-                // handle T[]
-                if (typeof(T).IsArray)
-                {
-                    var array = input as object[];
-                    return ConvertEnumerable(array);
-                }
-                else
-                {
-                    // handle T
-                    JObject data = JObject.FromObject(input);
-                    data[O365Constants.POCOKey] = true; // Set Microsoft.O365Bindings.POCO flag to indicate that data is from POCO (vs. object[][])
-
-                    return data;
-                }
-            }
-
-            /// <summary>
-            /// Convert from List<POCO> -> JObject
-            /// </summary>
-            /// <param name="input">POCO input from fx</param>
-            /// <returns>JObject with proper keys set</returns>
-            public JObject Convert(List<T> input)
-            {
-                return ConvertEnumerable(input);
-            }
-
-            private JObject ConvertEnumerable<U>(IEnumerable<U> input)
-            {
-                JObject jsonContent = new JObject();
-
-                JArray rowData = JArray.FromObject(input);
-
-                // List<T> -> JArray
-                jsonContent[O365Constants.ValuesKey] = rowData;
-
-                // Set rows, columns needed if updating entire worksheet
-                jsonContent[O365Constants.RowsKey] = rowData.Count();
-
-                // No exception -- array is rectangular by default
-                jsonContent[O365Constants.ColsKey] = rowData.First.Count();
-
-                // Set POCO key to indicate that the values need to be ordered to match the header of the existing table
-                jsonContent[O365Constants.POCOKey] = true;
-
-                return jsonContent;
-            }
-        }
-
-        /// <summary>
-        /// Used for INPUT bindings: convert Excel Attribute -> POCO inputs
-        /// </summary>
-        /// <typeparam name="T">POCO type user wishes to bind Excel contents to</typeparam>
-        internal class POCOConverter<T> : IAsyncConverter<ExcelAttribute, T[]>, IAsyncConverter<ExcelAttribute, List<T>>
-            where T : new()
-        {
-            private readonly ServiceManager _serviceManager;
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="POCOConverter{T}"/> class.
-            /// </summary>
-            /// <param name="parent">O365Extension to which the result of the request for data will be returned</param>
-            public POCOConverter(ServiceManager serviceManager)
-            {
-                this._serviceManager = serviceManager;
-            }
-
-            async Task<List<T>> IAsyncConverter<ExcelAttribute, List<T>>.ConvertAsync(ExcelAttribute input, CancellationToken cancellationToken)
-            {
-                var manager = await _serviceManager.GetExcelService(input);
-                return await manager.GetExcelRangePOCOListAsync<T>(input);
-            }
-
-            async Task<T[]> IAsyncConverter<ExcelAttribute, T[]>.ConvertAsync(ExcelAttribute input, CancellationToken cancellationToken)
-            {
-                var manager = await _serviceManager.GetExcelService(input);
-                return await manager.GetExcelRangePOCOAsync<T>(input);
-            }
-
-            public IAsyncCollector<JObject> CreateCollector(ExcelAttribute attr)
-            {
-                var manager = Task.Run(() => _serviceManager.GetExcelService(attr)).GetAwaiter().GetResult();
-                return new ExcelAsyncCollector(manager, attr);
-            }
-        }
-
-        /// <summary>
-        /// Used for input bindings; Attribute -> Input type
-        /// </summary>
-        internal class Converters :
-            IAsyncConverter<ExcelAttribute, string[][]>,
-            IAsyncConverter<ExcelAttribute, WorkbookTable>,
-            IAsyncConverter<OneDriveAttribute, byte[]>,
-            IAsyncConverter<OneDriveAttribute, string>,
-            IAsyncConverter<OneDriveAttribute, Stream>,
-            IAsyncConverter<OneDriveAttribute, DriveItem>,
-            IAsyncConverter<GraphWebhookSubscriptionAttribute, Subscription[]>,
-            IAsyncConverter<GraphWebhookSubscriptionAttribute, string[]>,
-            IAsyncConverter<GraphWebhookSubscriptionAttribute, JArray>
-        {
-            private readonly ServiceManager _serviceManager;
-            private readonly GraphWebhookConfig _webhookConfig;
-
-            public Converters(ServiceManager parent, GraphWebhookConfig webhookConfig)
-            {
-                _serviceManager = parent;
-                _webhookConfig = webhookConfig;
-            }
-
-            public IAsyncCollector<JObject> CreateCollector(ExcelAttribute attr)
-            {
-                var service = Task.Run(() => _serviceManager.GetExcelService(attr)).GetAwaiter().GetResult();
-                return new ExcelAsyncCollector(service, attr);
-            }
-
-            public IAsyncCollector<byte[]> CreateCollector(OneDriveAttribute attr)
-            {
-                var service = Task.Run(() => _serviceManager.GetOneDriveService(attr)).GetAwaiter().GetResult();
-                return new OneDriveAsyncCollector(service, attr);
-            }
-
-            public IAsyncCollector<Message> CreateCollector(OutlookAttribute attr)
-            {
-                var service = Task.Run(() => _serviceManager.GetOutlookService(attr)).GetAwaiter().GetResult();
-                return new OutlookAsyncCollector(service);
-            }
-
-            async Task<string[][]> IAsyncConverter<ExcelAttribute, string[][]>.ConvertAsync(ExcelAttribute attr, CancellationToken cancellationToken)
-            {
-                var service = await _serviceManager.GetExcelService(attr);
-                return await service.GetExcelRangeAsync(attr);
-            }
-
-            async Task<WorkbookTable> IAsyncConverter<ExcelAttribute, WorkbookTable>.ConvertAsync(ExcelAttribute input, CancellationToken cancellationToken)
-            {
-                var service = await _serviceManager.GetExcelService(input);
-                return await service.GetExcelTable(input);
-            }
-
-            async Task<byte[]> IAsyncConverter<OneDriveAttribute, byte[]>.ConvertAsync(OneDriveAttribute input, CancellationToken cancellationToken)
-            { 
-                var service = await _serviceManager.GetOneDriveService(input);
-                return await service.GetOneDriveContentsAsByteArrayAsync(input);
-            }
-
-            async Task<string> IAsyncConverter<OneDriveAttribute, string>.ConvertAsync(OneDriveAttribute input, CancellationToken cancellationToken)
-            {
-                var service = await _serviceManager.GetOneDriveService(input);
-                var byteArray = await service.GetOneDriveContentsAsByteArrayAsync(input);
-                return Encoding.UTF8.GetString(byteArray);
-            }
-
-            async Task<Stream> IAsyncConverter<OneDriveAttribute, Stream>.ConvertAsync(OneDriveAttribute input, CancellationToken cancellationToken)
-            {
-                var service = await _serviceManager.GetOneDriveService(input);
-                return await service.GetOneDriveContentsAsStreamAsync(input);
-            }
-
-            async Task<DriveItem> IAsyncConverter<OneDriveAttribute, DriveItem>.ConvertAsync(OneDriveAttribute input, CancellationToken cancellationToken)
-            {
-                var service = await _serviceManager.GetOneDriveService(input);
-                return await service.GetOneDriveItemAsync(input);
-            }
-
-            async Task<Subscription[]> IAsyncConverter<GraphWebhookSubscriptionAttribute, Subscription[]>.ConvertAsync(GraphWebhookSubscriptionAttribute input, CancellationToken cancellationToken)
-            {
-                return await GetSubscriptionsFromAttribute(input);
-            }
-
-            async Task<string[]> IAsyncConverter<GraphWebhookSubscriptionAttribute, string[]>.ConvertAsync(GraphWebhookSubscriptionAttribute input, CancellationToken cancellationToken)
-            {
-                Subscription[] subscriptions = await GetSubscriptionsFromAttribute(input);
-                return subscriptions.Select(sub => sub.Id).ToArray();
-            }
-
-            async Task<JArray> IAsyncConverter<GraphWebhookSubscriptionAttribute, JArray>.ConvertAsync(GraphWebhookSubscriptionAttribute input, CancellationToken cancellationToken)
-            {
-                Subscription[] subscriptions = await GetSubscriptionsFromAttribute(input);
-                var serializedSubscriptions = new JArray();
-                foreach (var subscription in subscriptions)
-                {
-                    serializedSubscriptions.Add(JObject.FromObject(subscription));
-                }
-                return serializedSubscriptions;
-            }
-
-            private async Task<Subscription[]> GetSubscriptionsFromAttribute(GraphWebhookSubscriptionAttribute attribute)
-            {
-                IEnumerable<SubscriptionEntry> subscriptionEntries = await _webhookConfig.SubscriptionStore.GetAllSubscriptionsAsync();
-                if (TokenIdentityMode.UserFromRequest.ToString().Equals(attribute.Filter, StringComparison.OrdinalIgnoreCase))
-                {
-                    var dummyTokenAttribute = new TokenAttribute()
-                    {
-                        Resource = O365Constants.GraphBaseUrl,
-                        Identity = TokenIdentityMode.UserFromToken,
-                        UserToken = attribute.UserToken,
-                        IdentityProvider = "AAD",
-                    };
-                    var graph = await _serviceManager.GetMSGraphClientAsync(dummyTokenAttribute);
-                    var user = await graph.Me.Request().GetAsync();
-                    subscriptionEntries = subscriptionEntries.Where(entry => entry.UserId.Equals(user.Id));
-                }
-                else if (attribute.Filter != null)
-                {
-                    throw new InvalidOperationException($"There is no filter for {attribute.Filter}");
-                }
-
-                return subscriptionEntries.Select(entry => entry.Subscription).ToArray();
-            }
         }
     }
 }

--- a/src/TokenBinding/AuthTokenExtensionConfig.cs
+++ b/src/TokenBinding/AuthTokenExtensionConfig.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
                     // If the attribute has no identity provider, assume AAD
                     attribute.IdentityProvider = attribute.IdentityProvider ?? "AAD";
                     string signingKey = AppSettings.Resolve(Constants.AppSettingWebsiteAuthSigningKey);
-                    var easyAuthTokenManager = new EasyAuthTokenManager(EasyAuthClient, _log, signingKey);
+                    var easyAuthTokenManager = new EasyAuthTokenManager(EasyAuthClient, signingKey);
                     return await easyAuthTokenManager.GetEasyAuthAccessTokenAsync(attribute);
                 case TokenIdentityMode.UserFromToken:
                     return await GetAuthTokenFromUserToken(attribute.UserToken, attribute.Resource);

--- a/src/TokenBinding/EasyAuthTokenClient.cs
+++ b/src/TokenBinding/EasyAuthTokenClient.cs
@@ -7,9 +7,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
     using System.IdentityModel.Tokens.Jwt;
     using System.Net;
     using System.Net.Http;
-    using System.Security.Claims;
     using System.Threading.Tasks;
-    using Microsoft.IdentityModel.Tokens;
     using Microsoft.Azure.WebJobs.Host;
     using Newtonsoft.Json;
 
@@ -18,18 +16,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
     /// </summary>
     internal class EasyAuthTokenClient : IEasyAuthClient
     {
-
-        internal static readonly JwtSecurityTokenHandler JwtHandler = new JwtSecurityTokenHandler();
-
         private static readonly HttpClient _httpClient = new HttpClient();
 
-        private static readonly int _jwtExpirationBufferInMinutes = 2;
-
-        private static readonly int _jwtTokenDurationInMinutes = 15;
-
         private readonly string _baseUrl;
-
-        private readonly string _signingKey;
 
         private readonly TraceWriter _log;
 
@@ -40,34 +29,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
         /// </summary>
         /// <param name="hostName">The hostname of the webapp </param>
         /// <param name="signingKey">The website authorization signing key</param>
-        public EasyAuthTokenClient(string hostName, string signingKey, TraceWriter log)
+        public EasyAuthTokenClient(string hostName, TraceWriter log)
         {
             _baseUrl = "https://" + hostName + "/";
-            _signingKey = signingKey;
             _log = log;
         }
 
-        private JwtSecurityToken GetTokenForEasyAuthAccess(TokenAttribute attribute)
+        public string GetBaseUrl()
         {
-            if (_tokenForEasyAuthAccess == null || _tokenForEasyAuthAccess.ValidTo <= DateTime.UtcNow.AddMinutes(_jwtExpirationBufferInMinutes))
-            {
-                _tokenForEasyAuthAccess = CreateTokenForEasyAuthAccess(attribute);
-            }
-
-            return _tokenForEasyAuthAccess;
+            return _baseUrl;
         }
 
-        public async Task<EasyAuthTokenStoreEntry> GetTokenStoreEntry(TokenAttribute attribute)
+        public async Task<EasyAuthTokenStoreEntry> GetTokenStoreEntry(JwtSecurityToken jwt, TokenAttribute attribute)
         {
-            var jwt = GetTokenForEasyAuthAccess(attribute);
-
             // Send the token to the local /.auth/me endpoint and return the JSON
             string meUrl = _baseUrl + $".auth/me?provider={attribute.IdentityProvider}";
 
             using (var request = new HttpRequestMessage(HttpMethod.Get, meUrl))
             {
                 request.Headers.Add("x-zumo-auth", jwt.RawData);
-                _log.Verbose($"Fetching user token data from ${meUrl}");
+                _log.Verbose($"Fetching user token data from {meUrl}");
                 using (HttpResponseMessage response = await _httpClient.SendAsync(request))
                 {
                     _log.Verbose($"Response from '${meUrl}: {response.StatusCode}");
@@ -82,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
             }
         }
 
-        public async Task RefreshToken(TokenAttribute attribute)
+        public async Task RefreshToken(JwtSecurityToken jwt, TokenAttribute attribute)
         {
             if (string.IsNullOrEmpty(attribute.Resource))
             {
@@ -103,7 +84,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
 
             using (var refreshRequest = new HttpRequestMessage(HttpMethod.Get, refreshUrl))
             {
-                var jwt = GetTokenForEasyAuthAccess(attribute);
                 refreshRequest.Headers.Add("x-zumo-auth", jwt.RawData);
                 _log.Verbose($"Refreshing ${attribute.IdentityProvider} access token for user ${attribute.UserId} at ${refreshUrl}");
                 using (HttpResponseMessage response = await _httpClient.SendAsync(refreshRequest))
@@ -115,142 +95,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
                         throw new InvalidOperationException($"Failed to refresh {attribute.UserId} {attribute.IdentityProvider} error={response.StatusCode} {errorResponse}");
                     }
                 }
-            }
-        }
-
-        private JwtSecurityToken CreateTokenForEasyAuthAccess(TokenAttribute attribute)
-        {
-            if (string.IsNullOrEmpty(attribute.UserId))
-            {
-                throw new ArgumentException("A userId is required to obtain an access token.");
-            }
-
-            if (string.IsNullOrEmpty(attribute.IdentityProvider))
-            {
-                throw new ArgumentException("A provider is necessary to obtain an access token.");
-            }
-
-            var identityClaims = new ClaimsIdentity(attribute.UserId);
-            identityClaims.AddClaim(new Claim(ClaimTypes.NameIdentifier, attribute.UserId));
-            identityClaims.AddClaim(new Claim("idp", attribute.IdentityProvider));
-
-            var descr = new SecurityTokenDescriptor
-            {
-                Audience = _baseUrl,
-                Issuer = _baseUrl,
-                Subject = identityClaims,
-                Expires = DateTime.UtcNow.AddMinutes(_jwtTokenDurationInMinutes),
-                SigningCredentials = new HmacSigningCredentials(_signingKey),
-            };
-
-            return (JwtSecurityToken)JwtHandler.CreateToken(descr);
-        }
-
-        public class HmacSigningCredentials : SigningCredentials
-        {
-            public HmacSigningCredentials(string base64EncodedKey)
-                : this(ParseKeyString(base64EncodedKey))
-            { }
-
-            public HmacSigningCredentials(byte[] key)
-                : base(new SymmetricSecurityKey(key), CreateSignatureAlgorithm(key))
-            {
-            }
-
-            /// <summary>
-            /// Converts a base64 OR hex-encoded string into a byte array.
-            /// </summary>
-            protected static byte[] ParseKeyString(string keyString)
-            {
-                if (string.IsNullOrEmpty(keyString))
-                {
-                    return new byte[0];
-                }
-                else if (IsHexString(keyString))
-                {
-                    return HexStringToByteArray(keyString);
-                }
-                else
-                {
-                    return Convert.FromBase64String(keyString);
-                }
-            }
-
-            protected static bool IsHexString(string input)
-            {
-                if (string.IsNullOrEmpty(input))
-                {
-                    throw new ArgumentNullException(nameof(input));
-                }
-
-                for (int i = 0; i < input.Length; i++)
-                {
-                    char c = input[i];
-                    bool isHexChar = (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
-                    if (!isHexChar)
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            protected static byte[] HexStringToByteArray(string hexString)
-            {
-                byte[] bytes = new byte[hexString.Length / 2];
-                for (int i = 0; i < hexString.Length; i += 2)
-                {
-                    bytes[i / 2] = Convert.ToByte(hexString.Substring(i, 2), 16);
-                }
-
-                return bytes;
-            }
-
-            protected static string CreateSignatureAlgorithm(byte[] key)
-            {
-                if (key.Length <= 32)
-                {
-                    return Algorithms.HmacSha256Signature;
-                }
-                else if (key.Length <= 48)
-                {
-                    return Algorithms.HmacSha384Signature;
-                }
-                else
-                {
-                    return Algorithms.HmacSha512Signature;
-                }
-            }
-
-            protected static string CreateDigestAlgorithm(byte[] key)
-            {
-                if (key.Length <= 32)
-                {
-                    return Algorithms.Sha256Digest;
-                }
-                else if (key.Length <= 48)
-                {
-                    return Algorithms.Sha384Digest;
-                }
-                else
-                {
-                    return Algorithms.Sha512Digest;
-                }
-            }
-
-            /// <summary>
-            /// Key value pairs (algorithm name, w3.org link)
-            /// </summary>
-            protected static class Algorithms
-            {
-                public const string HmacSha256Signature = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha256";
-                public const string HmacSha384Signature = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha384";
-                public const string HmacSha512Signature = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha512";
-
-                public const string Sha256Digest = "http://www.w3.org/2001/04/xmlenc#sha256";
-                public const string Sha384Digest = "http://www.w3.org/2001/04/xmlenc#sha384";
-                public const string Sha512Digest = "http://www.w3.org/2001/04/xmlenc#sha512";
             }
         }
     }

--- a/src/TokenBinding/EasyAuthTokenManager.cs
+++ b/src/TokenBinding/EasyAuthTokenManager.cs
@@ -4,7 +4,12 @@
 namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
 {
     using System;
+    using System.IdentityModel.Tokens.Jwt;
+    using System.Linq;
+    using System.Security.Claims;
     using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs.Host;
+    using Microsoft.IdentityModel.Tokens;
 
     /// <summary>
     /// Class representing an application's [EasyAuth] Token Store
@@ -12,18 +17,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
     /// </summary>
     internal class EasyAuthTokenManager
     {
+        internal static readonly JwtSecurityTokenHandler JwtHandler = new JwtSecurityTokenHandler();
+
+  
         private static readonly int GraphTokenBufferInMinutes = 5;
 
+        private static readonly int _jwtExpirationBufferInMinutes = 2;
+
+        private static readonly int _jwtTokenDurationInMinutes = 15;
+
+        private readonly string _signingKey;
+
         private readonly IEasyAuthClient _client;
+        private TraceWriter _log;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EasyAuthTokenManager"/> class.
         /// </summary>
         /// <param name="hostName">The hostname of the keystore. </param>
         /// <param name="signingKey">The website authorization signing key</param>
-        public EasyAuthTokenManager(IEasyAuthClient client)
+        public EasyAuthTokenManager(IEasyAuthClient client, TraceWriter log, string signingKey)
         {
             _client = client;
+            _log = log;
+            _signingKey = signingKey;
         }
 
         /// <summary>
@@ -33,7 +50,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
         /// <returns>Task with Token Store entry of the token</returns>
         public async Task<string> GetEasyAuthAccessTokenAsync(TokenAttribute attribute)
         {
-            EasyAuthTokenStoreEntry tokenStoreEntry = await _client.GetTokenStoreEntry(attribute);
+            var jwt = CreateTokenForEasyAuthAccess(attribute);
+            EasyAuthTokenStoreEntry tokenStoreEntry = await _client.GetTokenStoreEntry(jwt, attribute);
 
             bool isTokenValid = IsTokenValid(tokenStoreEntry.AccessToken);
             bool isTokenExpired = tokenStoreEntry.ExpiresOn <= DateTime.UtcNow.AddMinutes(GraphTokenBufferInMinutes);
@@ -41,10 +59,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
 
             if (isRefreshable && (isTokenExpired || !isTokenValid))
             {
-                await _client.RefreshToken(attribute);
+                await _client.RefreshToken(jwt, attribute);
 
                 // Now that the refresh has occured, grab the new token
-                tokenStoreEntry = await _client.GetTokenStoreEntry(attribute);
+                tokenStoreEntry = await _client.GetTokenStoreEntry(jwt, attribute);
             }
 
             return tokenStoreEntry.AccessToken;
@@ -52,13 +70,131 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
 
         private static bool IsTokenValid(string token)
         {
-            return EasyAuthTokenClient.JwtHandler.CanReadToken(token);
+            return JwtHandler.CanReadToken(token);
         }
 
         private static bool IsRefreshableProvider(string provider)
         {
             //TODO: For now, since we are focusing on AAD, only include it in the refresh path.
             return provider.Equals("AAD", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private JwtSecurityToken CreateTokenForEasyAuthAccess(TokenAttribute attribute)
+        {
+            if (string.IsNullOrEmpty(attribute.UserId))
+            {
+                throw new ArgumentException("A userId is required to obtain an access token.");
+            }
+
+            if (string.IsNullOrEmpty(attribute.IdentityProvider))
+            {
+                throw new ArgumentException("A provider is necessary to obtain an access token.");
+            }
+
+            var identityClaims = new ClaimsIdentity(attribute.UserId);
+            identityClaims.AddClaim(new System.Security.Claims.Claim(ClaimTypes.NameIdentifier, attribute.UserId));
+            identityClaims.AddClaim(new System.Security.Claims.Claim("idp", attribute.IdentityProvider));
+
+            var baseUrl = _client.GetBaseUrl();
+            var descr = new SecurityTokenDescriptor
+            {
+                Audience = baseUrl,
+                Issuer = baseUrl,
+                Subject = identityClaims,
+                Expires = DateTime.UtcNow.AddMinutes(_jwtTokenDurationInMinutes),
+                SigningCredentials = new HmacSigningCredentials(_signingKey),
+            };
+
+            return (JwtSecurityToken)JwtHandler.CreateToken(descr);
+        }
+
+
+        public class HmacSigningCredentials : SigningCredentials
+        {
+            public HmacSigningCredentials(string base64EncodedKey)
+                : this(ParseKeyString(base64EncodedKey))
+            { }
+
+            public HmacSigningCredentials(byte[] key)
+                : base(new SymmetricSecurityKey(key), CreateSignatureAlgorithm(key))
+            {
+            }
+
+            /// <summary>
+            /// Converts a base64 OR hex-encoded string into a byte array.
+            /// </summary>
+            protected static byte[] ParseKeyString(string keyString)
+            {
+                if (string.IsNullOrEmpty(keyString))
+                {
+                    return new byte[0];
+                }
+                else if (IsHexString(keyString))
+                {
+                    return HexStringToByteArray(keyString);
+                }
+                else
+                {
+                    return Convert.FromBase64String(keyString);
+                }
+            }
+
+            protected static bool IsHexString(string input)
+            {
+                if (string.IsNullOrEmpty(input))
+                {
+                    throw new ArgumentNullException(nameof(input));
+                }
+
+                for (int i = 0; i < input.Length; i++)
+                {
+                    char c = input[i];
+                    bool isHexChar = (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+                    if (!isHexChar)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            protected static byte[] HexStringToByteArray(string hexString)
+            {
+                byte[] bytes = new byte[hexString.Length / 2];
+                for (int i = 0; i < hexString.Length; i += 2)
+                {
+                    bytes[i / 2] = Convert.ToByte(hexString.Substring(i, 2), 16);
+                }
+
+                return bytes;
+            }
+
+            protected static string CreateSignatureAlgorithm(byte[] key)
+            {
+                if (key.Length <= 32)
+                {
+                    return Algorithms.HmacSha256Signature;
+                }
+                else if (key.Length <= 48)
+                {
+                    return Algorithms.HmacSha384Signature;
+                }
+                else
+                {
+                    return Algorithms.HmacSha512Signature;
+                }
+            }
+
+            /// <summary>
+            /// Key value pairs (algorithm name, w3.org link)
+            /// </summary>
+            protected static class Algorithms
+            {
+                public const string HmacSha256Signature = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha256";
+                public const string HmacSha384Signature = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha384";
+                public const string HmacSha512Signature = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha512";
+            }
         }
     }
 }

--- a/src/TokenBinding/EasyAuthTokenManager.cs
+++ b/src/TokenBinding/EasyAuthTokenManager.cs
@@ -29,17 +29,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
         private readonly string _signingKey;
 
         private readonly IEasyAuthClient _client;
-        private TraceWriter _log;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EasyAuthTokenManager"/> class.
         /// </summary>
         /// <param name="hostName">The hostname of the keystore. </param>
         /// <param name="signingKey">The website authorization signing key</param>
-        public EasyAuthTokenManager(IEasyAuthClient client, TraceWriter log, string signingKey)
+        public EasyAuthTokenManager(IEasyAuthClient client, string signingKey)
         {
             _client = client;
-            _log = log;
             _signingKey = signingKey;
         }
 

--- a/src/TokenBinding/IEasyAuthClient.cs
+++ b/src/TokenBinding/IEasyAuthClient.cs
@@ -5,12 +5,15 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
 {
+    using System.IdentityModel.Tokens.Jwt;
     using System.Threading.Tasks;
 
     internal interface IEasyAuthClient
     {
-        Task<EasyAuthTokenStoreEntry> GetTokenStoreEntry(TokenAttribute attribute);
+        Task<EasyAuthTokenStoreEntry> GetTokenStoreEntry(JwtSecurityToken jwt, TokenAttribute attribute);
 
-        Task RefreshToken(TokenAttribute attribute);
+        Task RefreshToken(JwtSecurityToken jwt, TokenAttribute attribute);
+
+        string GetBaseUrl();
     }
 }

--- a/src/TokenBinding/TokenIdentityMode.cs
+++ b/src/TokenBinding/TokenIdentityMode.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Azure.WebJobs
     /// </summary>
     public enum TokenIdentityMode
     {
-        /// <summary>Same as <see cref="UserFromToken"/> with the user token taken from the X-MS-TOKEN-AAD-ID-TOKEN header. Only works for HttpTrigger</summary>
-        UserFromRequest,
         /// <summary> Obtains the access token on behalf of the user whose token is in the userToken field of metadata. </summary>
         UserFromToken,
+        /// <summary>Same as <see cref="UserFromToken"/> with the user token taken from the X-MS-TOKEN-AAD-ID-TOKEN header. Only works for HttpTrigger</summary>
+        UserFromRequest, //This cannot be the default value, as it requires binding expressions that could cause errors.
         /// <summary> Obtains the access token for the user with the id found in the userId field of metadata. </summary>
         UserFromId,
         /// <summary> Obtains the access token for the client credentials found in the application settings. </summary>


### PR DESCRIPTION
In order to refresh subscription entries for all users without having an admin setup the application identity, we need to allow users to have access to the UserId and the Id attributes of the subscription that we store. This code has work to allow users to create a POCO with those fields as well as any other fields on the Subscription that they wish to access. This would allow users to write more complicated refresh calls, such as "Refresh only my mail subscriptions" or "Refresh only subscriptions that are updates".

In adding support for this, I also found a bug in cached user identity in the UserFromId mode. I simply removed the cached value.