### PR TITLE
Fix Excel POCO binding regression

### DIFF
--- a/src/MicrosoftGraphBinding/Services/ExcelClient.cs
+++ b/src/MicrosoftGraphBinding/Services/ExcelClient.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services
                 .HeaderRowRange()
                 .Request()
                 .GetAsync();
-            return headerRowRange.Values.ToObject<string[]>();
+            return headerRowRange.Values.ToObject<string[][]>()[0]; //header row array is embedded as the only element in its own array
         }
 
         public static async Task<WorkbookTableRow> PostTableRowAsync(this IGraphServiceClient client, string path, string tableName, JToken row)

--- a/test/MicrosoftGraph.Tests/ExcelTests.cs
+++ b/test/MicrosoftGraph.Tests/ExcelTests.cs
@@ -144,9 +144,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Tests
         public static async Task Update_WorksheetWithTable_SendsPatchWithProperValues()
         {
             var clientMock = new Mock<IGraphServiceClient>();
+            string[][] headerValues = new string[][] { GetHeaderRow() };
             var headerRow = new WorkbookRange()
             {
-                Values = JToken.FromObject(GetHeaderRow())
+                Values = JToken.FromObject(headerValues)
             };
             var address = new WorkbookRange()
             {
@@ -167,7 +168,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Tests
         private static Mock<IGraphServiceClient> AppendClientMock()
         {
             var clientMock = new Mock<IGraphServiceClient>();
-            string[] headerRow = GetHeaderRow();
+            string[][] headerRow = new string[][] { GetHeaderRow() };
             var workbookRange = new WorkbookRange()
             {
                 Values = JToken.FromObject(headerRow)
@@ -360,7 +361,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Tests
                 Path = path,
                 WorksheetName = worksheetName,
                 TableName = tableName,
-                UpdateType = "Update")] ICollector<SamplePoco> rows)
+                UpdateType = "Update")] ICollector<object> rows)
             {
                 foreach (var row in GetRangeAsPocoList())
                 {


### PR DESCRIPTION
Accidentally mocked incorrectly in refactor for tests in beta2. It turns out that the HeaderRowRange request is a jagged array of dimension 1xn, where the only element is the actual string[] that is the header row.