### PR TITLE
Fix tests that weren't checking parameters given to graph API

### DIFF
--- a/src/MicrosoftGraphBinding/Config/Converters/ExcelConverters.cs
+++ b/src/MicrosoftGraphBinding/Config/Converters/ExcelConverters.cs
@@ -16,13 +16,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Config.Converters
         internal class ExcelConverter : 
             IAsyncConverter<ExcelAttribute, string[][]>,
             IAsyncConverter<ExcelAttribute, WorkbookTable>,
-            IAsyncConverter<ExcelAttribute, IAsyncCollector<string>>
+            IAsyncConverter<ExcelAttribute, IAsyncCollector<string>>,
+            IConverter<JObject, string>
         {
             private readonly ServiceManager _serviceManager;
 
             public ExcelConverter(ServiceManager serviceManager)
             {
                 _serviceManager = serviceManager;
+            }
+
+            public string Convert(JObject input)
+            {
+                return input.ToString();
             }
 
             async Task<IAsyncCollector<string>> IAsyncConverter<ExcelAttribute, IAsyncCollector<string>>.ConvertAsync(ExcelAttribute attr, CancellationToken token)

--- a/src/MicrosoftGraphBinding/Config/MicrosoftGraphExtensionConfig.cs
+++ b/src/MicrosoftGraphBinding/Config/MicrosoftGraphExtensionConfig.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph
 
             // Excel Outputs
             ExcelRule.AddConverter<object[][], string>(ExcelService.CreateRows);
+            ExcelRule.AddConverter<JObject, string>(excelConverter);
             ExcelRule.AddOpenConverter<OpenType, string>(typeof(ExcelGenericsConverter<>), _serviceManager); // used to append/update arrays of POCOs
             ExcelRule.BindToCollector<string>(excelConverter);
 

--- a/src/MicrosoftGraphBinding/Services/ExcelService.cs
+++ b/src/MicrosoftGraphBinding/Services/ExcelService.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services
         /// <param name="attr">Excel Attribute with necessary data (workbook name, table name) to build request</param>
         /// <param name="jsonContent">JObject with the data to be added to the table</param>
         /// <returns>WorkbookTableRow that was just added</returns>
-        internal async Task<WorkbookTableRow> AddRow(ExcelAttribute attr, JObject jsonContent)
+        internal async Task AddRow(ExcelAttribute attr, JObject jsonContent)
         {
             /*
              * Two options:
@@ -121,14 +121,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Services
             }
             else if (jsonContent[O365Constants.ValuesKey] != null)
             {
-                newRow = jsonContent;
+                newRow = jsonContent[O365Constants.ValuesKey];
             }
             else
             {
                 throw new KeyNotFoundException($"When appending a row, the '{O365Constants.ValuesKey}' or '{O365Constants.POCOKey}' key must be set");
             }
 
-            return await _client.PostTableRowAsync(attr.Path, attr.TableName, newRow);
+            await _client.PostTableRowAsync(attr.Path, attr.TableName, newRow);
         }
 
         /// <summary>

--- a/test/MicrosoftGraph.Tests/ExcelMockUtilities.cs
+++ b/test/MicrosoftGraph.Tests/ExcelMockUtilities.cs
@@ -98,6 +98,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Tests
 
         public static void VerifyPostTableRowAsync(this Mock<IGraphServiceClient> mock, string path, string tableName, Expression<Func<JToken,bool>> rowCondition)
         {
+            //first verify PostAsync() called
             mock.Verify(client => client
                 .Me
                 .Drive
@@ -106,10 +107,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Tests
                 .Workbook
                 .Tables[tableName]
                 .Rows
-                .Add(null, It.Is<JToken>(rowCondition))
+                .Add(null, It.IsAny<JToken>())
                 .Request(null)
-                .PostAsync()
-            );
+                .PostAsync());
+
+            //Now verify row condition is true
+            mock.Verify(client => client
+                .Me
+                .Drive
+                .Root
+                .ItemWithPath(path)
+                .Workbook
+                .Tables[tableName]
+                .Rows
+                .Add(null, It.Is<JToken>(rowCondition)));
         }
 
         public static void MockPatchWorksheetAsync(this Mock<IGraphServiceClient> mock, WorkbookRange returnValue)

--- a/test/MicrosoftGraph.Tests/OneDriveMockUtilities.cs
+++ b/test/MicrosoftGraph.Tests/OneDriveMockUtilities.cs
@@ -37,12 +37,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Tests
 
         public static void VerifyGetOneDriveContentStreamFromShareAsync(this Mock<IGraphServiceClient> mock, string shareToken)
         {
+            //First verify GetAsync() called
             mock.Verify(client => client
                 .Shares[shareToken]
                 .Root
                 .Content
                 .Request(null)
                 .GetAsync());
+
+            //Then verify sharetoken correct
+            mock.Verify(client => client
+                .Shares[shareToken]);
         }
 
         public static void MockGetOneDriveItemAsync(this Mock<IGraphServiceClient> mock, DriveItem returnValue)

--- a/test/MicrosoftGraph.Tests/OutlookMockUtilities.cs
+++ b/test/MicrosoftGraph.Tests/OutlookMockUtilities.cs
@@ -14,28 +14,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Tests
         public static void MockSendMessage(this Mock<IGraphServiceClient> mock)
         {
             mock.Setup(client => client
-            .Me
-            .SendMail(It.IsAny<Message>(), true)
-            .Request(null)
-            .PostAsync()).Returns(Task.CompletedTask);
+                .Me
+                .SendMail(It.IsAny<Message>(), true)
+                .Request(null)
+                .PostAsync()).Returns(Task.CompletedTask);
         }
 
         public static void VerifySendMessage(this Mock<IGraphServiceClient> mock, Expression<Func<Message, bool>> messageCondition)
         {
+            // First verify PostAsync() called
             mock.Verify(client => client
-            .Me
-            .SendMail(It.Is<Message>(messageCondition), true)
-            .Request(null)
-            .PostAsync());
+                .Me
+                .SendMail(It.IsAny<Message>(), true)
+                .Request(null)
+                .PostAsync());
+
+            // Now verify that message condition holds for sent message
+            mock.Verify(client => client
+                .Me
+                .SendMail(It.Is<Message>(messageCondition), true));
         }
 
         public static void VerifyDidNotSendMessage(this Mock<IGraphServiceClient> mock)
         {
             mock.Verify(client => client
-            .Me
-            .SendMail(It.IsAny<Message>(), true)
-            .Request(null)
-            .PostAsync(), Times.Never());
+                .Me
+                .SendMail(It.IsAny<Message>(), true)
+                .Request(null)
+                .PostAsync(), Times.Never());
         }
     }
 }


### PR DESCRIPTION
It turns out that Verify with It.Is<> checks only work if the parameter is on the last set of calls, so I had to rewrite my tests. It turns out that some of the Excel Output tests were pretty broken, and in the process of fixing them, I also found/fixed a bug in the output binding to `out string[]`