### PR TITLE
Add Node support for Excel Output bindings

### DIFF
--- a/src/MicrosoftGraphBinding/Bindings/ExcelAsyncCollector.cs
+++ b/src/MicrosoftGraphBinding/Bindings/ExcelAsyncCollector.cs
@@ -64,9 +64,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph
                     // No exception -- array is rectangular by default
                     consolidatedRow[O365Constants.ColsKey] = array[0].Children().Count();
                     _rows.Add(consolidatedRow);
-                } else
+                }
+                else
                 {
-                    throw new InvalidOperationException("Only nested arrays are supported for JavaScript Excel output bindings.");
+                    throw new InvalidOperationException("Only nested arrays are supported for Excel output bindings.");
                 }
                 
             }

--- a/src/MicrosoftGraphBinding/Bindings/ExcelAsyncCollector.cs
+++ b/src/MicrosoftGraphBinding/Bindings/ExcelAsyncCollector.cs
@@ -64,6 +64,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph
                     // No exception -- array is rectangular by default
                     consolidatedRow[O365Constants.ColsKey] = array[0].Children().Count();
                     _rows.Add(consolidatedRow);
+                } else
+                {
+                    throw new InvalidOperationException("Only nested arrays are supported for JavaScript Excel output bindings.");
                 }
                 
             }


### PR DESCRIPTION
At some point I think Excel bindings (specifically Output) need a refactor. Right now they carry too much state on the JObject which is present in some conversions and not present in others, leading to some wacky logic in places.