### PR TITLE
Get token from function app's identity via MSI

### DIFF
--- a/src/TokenBinding/AadClient.cs
+++ b/src/TokenBinding/AadClient.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
 {
     using System;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Services.AppAuthentication;
     using Microsoft.Extensions.Options;
     using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
@@ -42,8 +43,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
                     }
                     _clientCredentials = new ClientCredential(_options.ClientId, _options.ClientSecret);
                 }
-                return _clientCredentials;
 
+                return _clientCredentials;
             }
         }
 
@@ -87,6 +88,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
 
             AuthenticationResult authResult = await AuthContext.AcquireTokenAsync(resource, ClientCredentials);
             return authResult.AccessToken;
+        }
+
+        public async Task<string> GetTokenFromAppIdentity(string resource)
+        {
+            if (string.IsNullOrEmpty(resource))
+            {
+                throw new ArgumentException("A resource is required to retrieve a token from the application's identity via MSI.");
+            }
+
+            var azureServiceTokenProvider = new AzureServiceTokenProvider();
+
+            var token = await azureServiceTokenProvider.GetAccessTokenAsync(resource);
+
+            return token;
         }
     }
 }

--- a/src/TokenBinding/AadClient.cs
+++ b/src/TokenBinding/AadClient.cs
@@ -90,14 +90,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
             return authResult.AccessToken;
         }
 
-        public async Task<string> GetTokenFromAppIdentity(string resource)
+        public async Task<string> GetTokenFromAppIdentity(string resource, string connectionString)
         {
             if (string.IsNullOrEmpty(resource))
             {
-                throw new ArgumentException("A resource is required to retrieve a token from the application's identity via MSI.");
+                throw new ArgumentException("A resource is required to retrieve a token via the application's managed identity.");
             }
 
-            var azureServiceTokenProvider = new AzureServiceTokenProvider();
+            var azureServiceTokenProvider = new AzureServiceTokenProvider(connectionString);
 
             var token = await azureServiceTokenProvider.GetAccessTokenAsync(resource);
 

--- a/src/TokenBinding/IAadClient.cs
+++ b/src/TokenBinding/IAadClient.cs
@@ -11,6 +11,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
 
         Task<string> GetTokenFromClientCredentials(string resource);
 
-        Task<string> GetTokenFromAppIdentity(string resource);
+        Task<string> GetTokenFromAppIdentity(string resource, string connectionString);
     }
 }

--- a/src/TokenBinding/IAadClient.cs
+++ b/src/TokenBinding/IAadClient.cs
@@ -10,5 +10,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
         Task<string> GetTokenOnBehalfOfUserAsync(string userToken, string resource);
 
         Task<string> GetTokenFromClientCredentials(string resource);
+
+        Task<string> GetTokenFromAppIdentity(string resource);
     }
 }

--- a/src/TokenBinding/TokenBaseAttribute.cs
+++ b/src/TokenBinding/TokenBaseAttribute.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs
         /// Gets or sets connection string to use for an application's managed identity. Optional
         /// </summary>
         [AutoResolve]
-        public string ConnectionString { get; set; }
+        public string IdentityConnectionString { get; set; }
 
         /// <summary>
         /// Gets or sets how to determine identity. Required.

--- a/src/TokenBinding/TokenBaseAttribute.cs
+++ b/src/TokenBinding/TokenBaseAttribute.cs
@@ -33,6 +33,12 @@ namespace Microsoft.Azure.WebJobs
         public string UserId { get; set; }
 
         /// <summary>
+        /// Gets or sets connection string to use for an application's managed identity. Optional
+        /// </summary>
+        [AutoResolve]
+        public string ConnectionString { get; set; }
+
+        /// <summary>
         /// Gets or sets how to determine identity. Required.
         /// </summary>
         public TokenIdentityMode Identity

--- a/src/TokenBinding/TokenBinding.csproj
+++ b/src/TokenBinding/TokenBinding.csproj
@@ -36,11 +36,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="1.0.3">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.14.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.14.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.4" />
   </ItemGroup>
 

--- a/src/TokenBinding/TokenConverter.cs
+++ b/src/TokenBinding/TokenConverter.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
                 case TokenIdentityMode.ClientCredentials:
                     return await _aadManager.GetTokenFromClientCredentials(attribute.Resource);
                 case TokenIdentityMode.AppIdentity:
-                    return await _aadManager.GetTokenFromAppIdentity(attribute.Resource, attribute.ConnectionString);
+                    return await _aadManager.GetTokenFromAppIdentity(attribute.Resource, attribute.IdentityConnectionString);
             }
 
             throw new InvalidOperationException("Unable to authorize without Principal ID or ID Token.");

--- a/src/TokenBinding/TokenConverter.cs
+++ b/src/TokenBinding/TokenConverter.cs
@@ -41,6 +41,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
                     return await GetAuthTokenFromUserToken(attribute.UserToken, attribute.Resource);
                 case TokenIdentityMode.ClientCredentials:
                     return await _aadManager.GetTokenFromClientCredentials(attribute.Resource);
+                case TokenIdentityMode.AppIdentity:
+                    return await _aadManager.GetTokenFromAppIdentity(attribute.Resource);
             }
 
             throw new InvalidOperationException("Unable to authorize without Principal ID or ID Token.");

--- a/src/TokenBinding/TokenConverter.cs
+++ b/src/TokenBinding/TokenConverter.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.AuthTokens
                 case TokenIdentityMode.ClientCredentials:
                     return await _aadManager.GetTokenFromClientCredentials(attribute.Resource);
                 case TokenIdentityMode.AppIdentity:
-                    return await _aadManager.GetTokenFromAppIdentity(attribute.Resource);
+                    return await _aadManager.GetTokenFromAppIdentity(attribute.Resource, attribute.ConnectionString);
             }
 
             throw new InvalidOperationException("Unable to authorize without Principal ID or ID Token.");

--- a/src/TokenBinding/TokenIdentityMode.cs
+++ b/src/TokenBinding/TokenIdentityMode.cs
@@ -16,5 +16,7 @@ namespace Microsoft.Azure.WebJobs
         UserFromId,
         /// <summary> Obtains the access token for the client credentials found in the application settings. </summary>
         ClientCredentials,
+        /// <summary> Obtains an access token for the application using the application's MSI identity</summary>
+        AppIdentity
     }
 }

--- a/src/TokenBinding/TokenIdentityMode.cs
+++ b/src/TokenBinding/TokenIdentityMode.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs
         UserFromId,
         /// <summary> Obtains the access token for the client credentials found in the application settings. </summary>
         ClientCredentials,
-        /// <summary> Obtains an access token for the application using the application's MSI identity</summary>
+        /// <summary> Obtains an access token for the application using the application's identity. </summary>
         AppIdentity
     }
 }


### PR DESCRIPTION
Uses MSI to get a token for a resource via the Function App's identity. The app must have MSI enabled, which sets the app settings MSI_ENDPOINT and MSI_SECRET.

Sample function.json snippet:
"name": "token",
"type": "token",
"direction": "in",
"identity": "appidentity",
"resource": "https://graph.microsoft.com"
"identityconnectionstring": "RunAs=App;AppId={AppId};TenantId={TenantId};AppKey={ClientSecret}"
