### PR TITLE
Use DI Container to initialize Option classes

### DIFF
--- a/src/MicrosoftGraphBinding/Config/MicrosoftGraphExtensionConfigProvider.cs
+++ b/src/MicrosoftGraphBinding/Config/MicrosoftGraphExtensionConfigProvider.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph
             IGraphSubscriptionStore subscriptionStore)
         {
             _options = options.Value;
-            _options.SetAppSettings(appSettings);
             _graphServiceClientManager = new GraphServiceClientManager(_options, tokenConverter, graphClientProvider);
             _subscriptionStore = subscriptionStore;
             _loggerFactory = loggerFactory;

--- a/src/MicrosoftGraphBinding/Config/MicrosoftGraphWebJobsBuilderExtensions.cs
+++ b/src/MicrosoftGraphBinding/Config/MicrosoftGraphWebJobsBuilderExtensions.cs
@@ -17,13 +17,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph.Config
             }
 
             builder.AddExtension<MicrosoftGraphExtensionConfigProvider>()
-                .BindOptions<GraphOptions>()
-                .BindOptions<TokenOptions>()
                 .Services
                 .AddAuthTokenServices()
                 .AddSingleton<IAsyncConverter<TokenBaseAttribute, string>, TokenConverter>()
                 .AddSingleton<IGraphServiceClientProvider, GraphServiceClientProvider>()
-                .AddSingleton<IGraphSubscriptionStore, WebhookSubscriptionStore>();
+                .AddSingleton<IGraphSubscriptionStore, WebhookSubscriptionStore>()
+                .AddOptions<GraphOptions>().Configure<INameResolver>((option, appSettings) =>
+                {
+                    option.SetAppSettings(appSettings);
+                })
+                .Services
+                .AddOptions<TokenOptions>().Configure<INameResolver>((option, appSettings) =>
+                {
+                    option.SetAppSettings(appSettings);
+                });
+
             return builder;
         }
 


### PR DESCRIPTION
# Issue

When using the Azure functions microsoft graph extension version 1.0.0-beta6 the Azure function application reports an AccessDenied Exception:

![image](https://user-images.githubusercontent.com/1760777/72205778-30ab8d80-3487-11ea-92fd-58802168e030.png)

This error was already reported in #108 and fixed in #77. However, even when using the dev branch, the exception is still thrown.

# Cause

While #77 has done some fixing in the `GraphOptions` class, the cause for this exception comes from the order in which `MicrosoftGraphExtensionConfigProvider` and `WebhookSubscriptionStore` are created by the DI Container.

The exception is thrown by the constructor of the `WebhookSubscriptionStore`, which tries to create the `BYOB_TokenMap` directory:

```csharp
public WebhookSubscriptionStore(IOptions<GraphOptions> options)
{
    _options = options.Value;
    _fileLock = new FileLock();
    _fileLock.PerformWriteIO(_options.TokenMapLocation, () => CreateRootDirectory());
}
```

This directory is configured by the `BYOB_TokenMap` app setting and applied to the `GraphOptions` class by calling `GraphOptions.SetAppSettings()`. The call to this method is done inside the constructor of the `MicrosoftGraphExtensionConfigProvider` class:

```csharp
public MicrosoftGraphExtensionConfigProvider(IOptions<GraphOptions> options, 
            ILoggerFactory loggerFactory, 
            IGraphServiceClientProvider graphClientProvider, 
            INameResolver appSettings,
            IAsyncConverter<TokenBaseAttribute, string> tokenConverter,
            IGraphSubscriptionStore subscriptionStore)
        {
            _options = options.Value;
            _options.SetAppSettings(appSettings);
            _graphServiceClientManager = new GraphServiceClientManager(_options, tokenConverter, graphClientProvider);
            _subscriptionStore = subscriptionStore;
            _loggerFactory = loggerFactory;
        }
```  

# Fix

Applying the values from the app settings to the Options classes should be done outside those infrastructure classes, because their initialization order depends on the DI Container.

This PR moves the initialization of those Options classes to the DI container.

